### PR TITLE
feat: add get demo page

### DIFF
--- a/app/(site)/blog/sections/hero.tsx
+++ b/app/(site)/blog/sections/hero.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
 import { ButtonDuo } from "@/components/ui/button-duo";
 import { Animate } from "@/components/ui/animate";
-import { CALENDLY_URL } from "@/lib/config";
 
 export const sectionId = "hero";
 
@@ -16,7 +15,7 @@ type Copy = {
 const copy = {
   title: "Latest from Subsights",
   subtitle: "Clear guides, product updates, and field notes from the team",
-  primaryCta: { label: "Book Demo", href: CALENDLY_URL },
+  primaryCta: { label: "Get Demo", href: "/get-demo" },
   secondaryCta: { label: "Read Posts", href: "#posts" },
 } satisfies Copy;
 // ---- /SECTION COPY REGION ----
@@ -42,11 +41,7 @@ export default function Hero() {
               <ButtonDuo
                 primary={{
                   asChild: true,
-                  children: (
-                    <a href={c.primaryCta.href} target="_blank" rel="noopener noreferrer">
-                      {c.primaryCta.label}
-                    </a>
-                  ),
+                  children: <Link href={c.primaryCta.href}>{c.primaryCta.label}</Link>,
                   size: "lg",
                   dataAttributes: {
                     "data-analytics-id": "blog_hero_demo",

--- a/app/(site)/case-studies/[slug]/sections/call-to-action.tsx
+++ b/app/(site)/case-studies/[slug]/sections/call-to-action.tsx
@@ -1,6 +1,5 @@
 import { Cta } from "@/components/ui/cta";
 import { Animate } from "@/components/ui/animate";
-import { CALENDLY_URL } from "@/lib/config";
 import { getFreeTrialUrl } from "@/lib/subscriptions";
 
 type Copy = {
@@ -16,7 +15,7 @@ export const sectionId = "call-to-action";
 const copy = {
   title: "Ready to see similar results?",
   subtitle: "Join the growing list of satisfied customers",
-  primaryCta: { label: "Book Demo", href: CALENDLY_URL, external: true },
+  primaryCta: { label: "Get Demo", href: "/get-demo", external: false },
   secondaryCta: { label: "Start Free", href: getFreeTrialUrl(), external: true },
 } satisfies Copy;
 // ---- /SECTION COPY REGION ----

--- a/app/(site)/case-studies/sections/call-to-action.tsx
+++ b/app/(site)/case-studies/sections/call-to-action.tsx
@@ -1,6 +1,5 @@
 import { Cta } from "@/components/ui/cta";
 import { Animate } from "@/components/ui/animate";
-import { CALENDLY_URL } from "@/lib/config";
 import { getFreeTrialUrl } from "@/lib/subscriptions";
 
 type Copy = {
@@ -14,7 +13,7 @@ export const sectionId = "call-to-action";
 // ---- SECTION COPY REGION ----
 const copy = {
   title: "Ready to see similar results?",
-  primaryCta: { label: "Book Demo", href: CALENDLY_URL, external: true },
+  primaryCta: { label: "Get Demo", href: "/get-demo", external: false },
   secondaryCta: { label: "Start Free", href: getFreeTrialUrl(), external: true },
 } satisfies Copy;
 // ---- /SECTION COPY REGION ----

--- a/app/(site)/case-studies/sections/hero.tsx
+++ b/app/(site)/case-studies/sections/hero.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
 import { ButtonDuo } from "@/components/ui/button-duo";
 import { Animate } from "@/components/ui/animate";
-import { CALENDLY_URL } from "@/lib/config";
 
 type Copy = {
   title: string;
@@ -16,7 +15,7 @@ export const sectionId = "hero";
 const copy = {
   title: "Meet the teams who support customers 24/7",
   subtitle: "Subsights powers consistent answers, faster routing, and better outcomes",
-  primaryCta: { label: "Book Demo", href: CALENDLY_URL },
+  primaryCta: { label: "Get Demo", href: "/get-demo" },
   secondaryCta: { label: "View Case Studies", href: "#customer-stories" },
 } satisfies Copy;
 // ---- /SECTION COPY REGION ----
@@ -43,15 +42,11 @@ export default function Hero() {
               <ButtonDuo
                 primary={{
                   asChild: true,
-                  children: (
-                    <a href={c.primaryCta.href} target="_blank" rel="noopener noreferrer">
-                      {c.primaryCta.label}
-                    </a>
-                  ),
+                  children: <Link href={c.primaryCta.href}>{c.primaryCta.label}</Link>,
                   size: "lg",
                   dataAttributes: {
                     "data-analytics-id": "case_studies_hero_demo",
-                    "data-analytics-name": "Book Demo (Case Studies Hero)",
+                    "data-analytics-name": "Get Demo (Case Studies Hero)",
                     "data-analytics-context": '{"source":"case_studies_hero","section":"hero"}',
                   },
                 }}

--- a/app/(site)/get-demo/page.tsx
+++ b/app/(site)/get-demo/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+import { buildMetadata } from "@/lib/seo";
+import Hero from "./sections/hero";
+
+export const metadata: Metadata = buildMetadata({
+  title: "Get Demo",
+  description: "Book a live demo or share your details to explore Subsights.",
+  path: "/get-demo",
+  image: "/images/logo/small-logo.svg",
+});
+
+export default function GetDemo() {
+  const Sections = [Hero];
+  return (
+    <main className="min-h-screen">
+      {Sections.map((S, i) => (
+        <S key={i} />
+      ))}
+    </main>
+  );
+}

--- a/app/(site)/get-demo/sections/hero.tsx
+++ b/app/(site)/get-demo/sections/hero.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Animate } from "@/components/ui/animate";
+import { CALENDLY_URL } from "@/lib/config";
+
+export default function Hero() {
+  return (
+    <section className="relative isolate px-6 py-12">
+      <Animate name="fadeInStagger" trigger="onVisible">
+        <div className="max-w-3xl mx-auto space-y-8">
+          <h1 className="animate-item text-4xl md:text-5xl font-bold text-center tracking-tight">
+            Get a Demo
+          </h1>
+          <div className="animate-item grid gap-8 md:grid-cols-2">
+            <div className="flex justify-center">
+              <Button
+                asChild
+                size="lg"
+                data-analytics-id="get_demo_book_demo"
+                data-analytics-name="Book Demo (Get Demo)"
+                data-analytics-context='{"source":"get_demo","section":"hero"}'
+              >
+                <a href={CALENDLY_URL} target="_blank" rel="noopener noreferrer">
+                  Book Demo
+                </a>
+              </Button>
+            </div>
+            <form className="flex flex-col gap-4" onSubmit={(e) => e.preventDefault()}>
+              <div className="flex flex-col space-y-1">
+                <label htmlFor="email" className="text-sm font-medium">
+                  Email <span className="text-destructive">*</span>
+                </label>
+                <Input id="email" type="email" required />
+              </div>
+              <div className="flex flex-col space-y-1">
+                <label htmlFor="website" className="text-sm font-medium">
+                  Your website url
+                </label>
+                <Input id="website" type="url" />
+              </div>
+              <Button
+                type="submit"
+                size="lg"
+                data-analytics-id="get_demo_form_submit"
+                data-analytics-name="Submit (Get Demo)"
+                data-analytics-context='{"source":"get_demo","section":"form"}'
+              >
+                Submit
+              </Button>
+            </form>
+          </div>
+        </div>
+      </Animate>
+    </section>
+  )
+}
+
+export const sectionId = "hero";

--- a/app/(site)/home/sections/call-to-action.tsx
+++ b/app/(site)/home/sections/call-to-action.tsx
@@ -1,6 +1,5 @@
 import { Cta } from "@/components/ui/cta";
 import { Animate } from "@/components/ui/animate";
-import { CALENDLY_URL } from "@/lib/config";
 import { getFreeTrialUrl } from "@/lib/subscriptions";
 
 type Copy = {
@@ -14,7 +13,7 @@ export const sectionId = "call-to-action";
 // ---- SECTION COPY REGION ----
 const copy = {
   title: "Make every visit count.",
-  primaryCta: { label: "Book Demo", href: CALENDLY_URL, external: true },
+  primaryCta: { label: "Get Demo", href: "/get-demo", external: false },
   secondaryCta: { label: "Start Free", href: getFreeTrialUrl(), external: true },
 } satisfies Copy;
 // ---- /SECTION COPY REGION ----

--- a/app/(site)/home/sections/hero.tsx
+++ b/app/(site)/home/sections/hero.tsx
@@ -1,6 +1,6 @@
 import { Animate } from "@/components/ui/animate";
 import { ButtonDuo } from "@/components/ui/button-duo";
-import { CALENDLY_URL } from "@/lib/config";
+import Link from "next/link";
 import CurvedArrow from "@/components/home/curved-arrow";
 
 type Copy = {
@@ -25,7 +25,7 @@ const copy = {
     mobile: "Subsights is the system that streamlines support, lead qualification, and revenue growth.",
     desktop: "Meet the system that streamlines support, lead qualification, and revenue growth.",
   },
-  primaryCta: { label: "Book Demo", href: CALENDLY_URL },
+  primaryCta: { label: "Get Demo", href: "/get-demo" },
   secondaryCta: { label: "Watch Overview", href: "https://www.youtube.com/watch?v=OlwA_a5CpYQ&list=PLXL5IEY-s71AWou876UpvgX8r0W5B2Whc" },
 } satisfies Copy;
 
@@ -66,15 +66,11 @@ export default function Hero() {
           <ButtonDuo
             primary={{
               asChild: true,
-              children: (
-                <a href={copy.primaryCta.href} target="_blank" rel="noopener noreferrer">
-                  {copy.primaryCta.label}
-                </a>
-              ),
+              children: <Link href={copy.primaryCta.href}>{copy.primaryCta.label}</Link>,
               size: "lg",
               dataAttributes: {
                 "data-analytics-id": "home_hero_demo_duo",
-                "data-analytics-name": "Book Demo (Home Hero Duo)",
+                "data-analytics-name": "Get Demo (Home Hero Duo)",
                 "data-analytics-context": '{"source":"home_hero","section":"hero","variant":"duo"}',
               },
             }}

--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -5,7 +5,6 @@ import type { ReactNode } from "react";
 import type { Metadata } from "next";
 import { Suspense } from "react";
 import { Button } from "@/components/ui/button";
-import { CALENDLY_URL } from "@/lib/config";
 import { Animate } from "@/components/ui/animate";
 import { Sheet, SheetContent, SheetTrigger, SheetTitle, SheetClose } from "@/components/ui/sheet";
 import { Menu } from "lucide-react";
@@ -50,7 +49,7 @@ function buildNavigationItems() {
     { label: "About", href: "/about" },
     { label: "Blog", href: "/blog" },
     { label: "FAQ", href: "/faq" },
-    { label: "Book Demo", href: CALENDLY_URL, isButton: true },
+    { label: "Get Demo", href: "/get-demo", isButton: true },
   ] as (NavItem & { isButton?: boolean })[];
 }
 
@@ -87,12 +86,10 @@ const DesktopNavigation = () => {
                   asChild
                   size="sm"
                   data-analytics-id="nav_desktop_demo"
-                  data-analytics-name="Book Demo (Nav)"
+                  data-analytics-name="Get Demo (Nav)"
                   data-analytics-context='{"source":"nav_desktop","location":"header"}'
                 >
-                  <a href={item.href} target="_blank" rel="noopener noreferrer">
-                    {item.label}
-                  </a>
+                  <Link href={item.href}>{item.label}</Link>
                 </Button>
               ) : (
                 <NavigationMenuLink
@@ -146,12 +143,10 @@ const MobileNavigation = () => {
                     asChild
                     className="w-full"
                     data-analytics-id="nav_mobile_demo"
-                    data-analytics-name="Book Demo (Nav Mobile)"
+                    data-analytics-name="Get Demo (Nav Mobile)"
                     data-analytics-context='{"source":"nav_mobile","location":"sheet"}'
                   >
-                    <a href={item.href} target="_blank" rel="noopener noreferrer">
-                      {item.label}
-                    </a>
+                    <Link href={item.href}>{item.label}</Link>
                   </Button>
                 </SheetClose>
               ) : (


### PR DESCRIPTION
## Summary
- link demo CTAs and nav button to new internal route
- add /get-demo page with booking button and lead form

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b1db8090908327b78e3ed610af4369