### PR TITLE
Add demo request page and update CTAs

### DIFF
--- a/app/(site)/blog/sections/hero.tsx
+++ b/app/(site)/blog/sections/hero.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
 import { ButtonDuo } from "@/components/ui/button-duo";
 import { Animate } from "@/components/ui/animate";
-import { CALENDLY_URL } from "@/lib/config";
 
 export const sectionId = "hero";
 
@@ -16,7 +15,7 @@ type Copy = {
 const copy = {
   title: "Latest from Subsights",
   subtitle: "Clear guides, product updates, and field notes from the team",
-  primaryCta: { label: "Book Demo", href: CALENDLY_URL },
+  primaryCta: { label: "Get Demo", href: "/get-demo" },
   secondaryCta: { label: "Read Posts", href: "#posts" },
 } satisfies Copy;
 // ---- /SECTION COPY REGION ----
@@ -43,20 +42,23 @@ export default function Hero() {
                 primary={{
                   asChild: true,
                   children: (
-                    <a href={c.primaryCta.href} target="_blank" rel="noopener noreferrer">
-                      {c.primaryCta.label}
-                    </a>
+                    <Link href={c.primaryCta.href}>{c.primaryCta.label}</Link>
                   ),
                   size: "lg",
                   dataAttributes: {
                     "data-analytics-id": "blog_hero_demo",
                     "data-analytics-name": "Get Demo (Blog Hero)",
-                    "data-analytics-context": '{"source":"blog_hero","section":"hero"}',
+                    "data-analytics-context":
+                      '{"source":"blog_hero","section":"hero"}',
                   },
                 }}
                 secondary={{
                   asChild: true,
-                  children: <Link href={c.secondaryCta.href}>{c.secondaryCta.label}</Link>,
+                  children: (
+                    <Link href={c.secondaryCta.href}>
+                      {c.secondaryCta.label}
+                    </Link>
+                  ),
                   variant: "outline",
                   size: "lg",
                 }}

--- a/app/(site)/case-studies/[slug]/sections/call-to-action.tsx
+++ b/app/(site)/case-studies/[slug]/sections/call-to-action.tsx
@@ -1,6 +1,5 @@
 import { Cta } from "@/components/ui/cta";
 import { Animate } from "@/components/ui/animate";
-import { CALENDLY_URL } from "@/lib/config";
 import { getFreeTrialUrl } from "@/lib/subscriptions";
 
 type Copy = {
@@ -16,8 +15,12 @@ export const sectionId = "call-to-action";
 const copy = {
   title: "Ready to see similar results?",
   subtitle: "Join the growing list of satisfied customers",
-  primaryCta: { label: "Book Demo", href: CALENDLY_URL, external: true },
-  secondaryCta: { label: "Start Free", href: getFreeTrialUrl(), external: true },
+  primaryCta: { label: "Get Demo", href: "/get-demo", external: false },
+  secondaryCta: {
+    label: "Start Free",
+    href: getFreeTrialUrl(),
+    external: true,
+  },
 } satisfies Copy;
 // ---- /SECTION COPY REGION ----
 

--- a/app/(site)/case-studies/sections/call-to-action.tsx
+++ b/app/(site)/case-studies/sections/call-to-action.tsx
@@ -1,6 +1,5 @@
 import { Cta } from "@/components/ui/cta";
 import { Animate } from "@/components/ui/animate";
-import { CALENDLY_URL } from "@/lib/config";
 import { getFreeTrialUrl } from "@/lib/subscriptions";
 
 type Copy = {
@@ -14,8 +13,12 @@ export const sectionId = "call-to-action";
 // ---- SECTION COPY REGION ----
 const copy = {
   title: "Ready to see similar results?",
-  primaryCta: { label: "Book Demo", href: CALENDLY_URL, external: true },
-  secondaryCta: { label: "Start Free", href: getFreeTrialUrl(), external: true },
+  primaryCta: { label: "Get Demo", href: "/get-demo", external: false },
+  secondaryCta: {
+    label: "Start Free",
+    href: getFreeTrialUrl(),
+    external: true,
+  },
 } satisfies Copy;
 // ---- /SECTION COPY REGION ----
 

--- a/app/(site)/case-studies/sections/hero.tsx
+++ b/app/(site)/case-studies/sections/hero.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
 import { ButtonDuo } from "@/components/ui/button-duo";
 import { Animate } from "@/components/ui/animate";
-import { CALENDLY_URL } from "@/lib/config";
 
 type Copy = {
   title: string;
@@ -15,8 +14,9 @@ export const sectionId = "hero";
 // ---- SECTION COPY REGION ----
 const copy = {
   title: "Meet the teams who support customers 24/7",
-  subtitle: "Subsights powers consistent answers, faster routing, and better outcomes",
-  primaryCta: { label: "Book Demo", href: CALENDLY_URL },
+  subtitle:
+    "Subsights powers consistent answers, faster routing, and better outcomes",
+  primaryCta: { label: "Get Demo", href: "/get-demo" },
   secondaryCta: { label: "View Case Studies", href: "#customer-stories" },
 } satisfies Copy;
 // ---- /SECTION COPY REGION ----
@@ -44,20 +44,23 @@ export default function Hero() {
                 primary={{
                   asChild: true,
                   children: (
-                    <a href={c.primaryCta.href} target="_blank" rel="noopener noreferrer">
-                      {c.primaryCta.label}
-                    </a>
+                    <Link href={c.primaryCta.href}>{c.primaryCta.label}</Link>
                   ),
                   size: "lg",
                   dataAttributes: {
                     "data-analytics-id": "case_studies_hero_demo",
-                    "data-analytics-name": "Book Demo (Case Studies Hero)",
-                    "data-analytics-context": '{"source":"case_studies_hero","section":"hero"}',
+                    "data-analytics-name": "Get Demo (Case Studies Hero)",
+                    "data-analytics-context":
+                      '{"source":"case_studies_hero","section":"hero"}',
                   },
                 }}
                 secondary={{
                   asChild: true,
-                  children: <Link href={c.secondaryCta.href}>{c.secondaryCta.label}</Link>,
+                  children: (
+                    <Link href={c.secondaryCta.href}>
+                      {c.secondaryCta.label}
+                    </Link>
+                  ),
                   variant: "outline",
                   size: "lg",
                 }}

--- a/app/(site)/get-demo/page.tsx
+++ b/app/(site)/get-demo/page.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+import { buildMetadata } from "@/lib/seo";
+import Hero from "./sections/hero";
+
+export const metadata: Metadata = buildMetadata({
+  title: "Get Demo",
+  description: "Choose how you’d like to see Subsights in action.",
+  path: "/get-demo",
+});
+
+export default function Page() {
+  const Sections = [Hero];
+  return (
+    <main>
+      {Sections.map((S, i) => (
+        <S key={i} />
+      ))}
+    </main>
+  );
+}

--- a/app/(site)/get-demo/sections/hero.tsx
+++ b/app/(site)/get-demo/sections/hero.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { FormEvent } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Animate } from "@/components/ui/animate";
+import { CALENDLY_URL } from "@/lib/config";
+
+export default function Hero() {
+  function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+  }
+
+  return (
+    <section className="px-6 py-12 max-w-3xl mx-auto text-center">
+      <Animate name="fadeInStagger" trigger="onVisible">
+        <h1 className="animate-item text-4xl md:text-5xl font-bold tracking-tight mb-6">
+          Get Demo
+        </h1>
+        <div className="animate-item mb-8">
+          <Button
+            asChild
+            size="lg"
+            data-analytics-id="get_demo_book"
+            data-analytics-name="Book Demo (Get Demo)"
+            data-analytics-context='{"source":"get_demo","section":"hero"}'
+          >
+            <a href={CALENDLY_URL} target="_blank" rel="noopener noreferrer">
+              Book demo
+            </a>
+          </Button>
+        </div>
+        <form
+          onSubmit={handleSubmit}
+          className="animate-item mx-auto max-w-sm space-y-4"
+        >
+          <div className="flex flex-col items-start gap-2">
+            <label htmlFor="email" className="text-sm font-medium">
+              Email <span className="text-destructive">*</span>
+            </label>
+            <Input id="email" type="email" required />
+          </div>
+          <div className="flex flex-col items-start gap-2">
+            <label htmlFor="website" className="text-sm font-medium">
+              Your website url
+            </label>
+            <Input id="website" type="url" />
+          </div>
+          <Button
+            type="submit"
+            className="w-full"
+            data-analytics-id="get_demo_submit"
+            data-analytics-name="Submit (Get Demo)"
+            data-analytics-context='{"source":"get_demo","section":"hero"}'
+          >
+            Submit
+          </Button>
+        </form>
+      </Animate>
+    </section>
+  );
+}
+
+export const sectionId = "hero";

--- a/app/(site)/home/sections/call-to-action.tsx
+++ b/app/(site)/home/sections/call-to-action.tsx
@@ -1,6 +1,5 @@
 import { Cta } from "@/components/ui/cta";
 import { Animate } from "@/components/ui/animate";
-import { CALENDLY_URL } from "@/lib/config";
 import { getFreeTrialUrl } from "@/lib/subscriptions";
 
 type Copy = {
@@ -14,8 +13,12 @@ export const sectionId = "call-to-action";
 // ---- SECTION COPY REGION ----
 const copy = {
   title: "Make every visit count.",
-  primaryCta: { label: "Book Demo", href: CALENDLY_URL, external: true },
-  secondaryCta: { label: "Start Free", href: getFreeTrialUrl(), external: true },
+  primaryCta: { label: "Get Demo", href: "/get-demo", external: false },
+  secondaryCta: {
+    label: "Start Free",
+    href: getFreeTrialUrl(),
+    external: true,
+  },
 } satisfies Copy;
 // ---- /SECTION COPY REGION ----
 

--- a/app/(site)/home/sections/hero.tsx
+++ b/app/(site)/home/sections/hero.tsx
@@ -1,6 +1,6 @@
+import Link from "next/link";
 import { Animate } from "@/components/ui/animate";
 import { ButtonDuo } from "@/components/ui/button-duo";
-import { CALENDLY_URL } from "@/lib/config";
 import CurvedArrow from "@/components/home/curved-arrow";
 
 type Copy = {
@@ -19,14 +19,19 @@ type Copy = {
 const copy = {
   slogan: {
     mobile: "Meet your AI teammate",
-    desktop: "Subsights is the AI teammate for modern websites"
+    desktop: "Subsights is the AI teammate for modern websites",
   },
   description: {
-    mobile: "Subsights is the system that streamlines support, lead qualification, and revenue growth.",
-    desktop: "Meet the system that streamlines support, lead qualification, and revenue growth.",
+    mobile:
+      "Subsights is the system that streamlines support, lead qualification, and revenue growth.",
+    desktop:
+      "Meet the system that streamlines support, lead qualification, and revenue growth.",
   },
-  primaryCta: { label: "Book Demo", href: CALENDLY_URL },
-  secondaryCta: { label: "Watch Overview", href: "https://www.youtube.com/watch?v=OlwA_a5CpYQ&list=PLXL5IEY-s71AWou876UpvgX8r0W5B2Whc" },
+  primaryCta: { label: "Get Demo", href: "/get-demo" },
+  secondaryCta: {
+    label: "Watch Overview",
+    href: "https://www.youtube.com/watch?v=OlwA_a5CpYQ&list=PLXL5IEY-s71AWou876UpvgX8r0W5B2Whc",
+  },
 } satisfies Copy;
 
 export default function Hero() {
@@ -48,7 +53,10 @@ export default function Hero() {
       />
       {/* Slogan */}
       <Animate name="fadeInStagger" trigger="onVisible">
-        <h2 id="home-hero-title" className="animate-item text-4xl md:text-5xl font-bold tracking-tight leading-tight mb-4 max-w-2xl text-center mx-auto">
+        <h2
+          id="home-hero-title"
+          className="animate-item text-4xl md:text-5xl font-bold tracking-tight leading-tight mb-4 max-w-2xl text-center mx-auto"
+        >
           <span className="block md:hidden">{copy.slogan.mobile}</span>
           <span className="hidden md:block">{copy.slogan.desktop}</span>
         </h2>
@@ -67,21 +75,24 @@ export default function Hero() {
             primary={{
               asChild: true,
               children: (
-                <a href={copy.primaryCta.href} target="_blank" rel="noopener noreferrer">
-                  {copy.primaryCta.label}
-                </a>
+                <Link href={copy.primaryCta.href}>{copy.primaryCta.label}</Link>
               ),
               size: "lg",
               dataAttributes: {
                 "data-analytics-id": "home_hero_demo_duo",
-                "data-analytics-name": "Book Demo (Home Hero Duo)",
-                "data-analytics-context": '{"source":"home_hero","section":"hero","variant":"duo"}',
+                "data-analytics-name": "Get Demo (Home Hero Duo)",
+                "data-analytics-context":
+                  '{"source":"home_hero","section":"hero","variant":"duo"}',
               },
             }}
             secondary={{
               asChild: true,
               children: (
-                <a href={copy.secondaryCta.href} target="_blank" rel="noopener noreferrer">
+                <a
+                  href={copy.secondaryCta.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
                   {copy.secondaryCta.label}
                 </a>
               ),
@@ -90,7 +101,8 @@ export default function Hero() {
               dataAttributes: {
                 "data-analytics-id": "home_hero_watch_duo",
                 "data-analytics-name": "Watch Overview (Home Hero Duo)",
-                "data-analytics-context": '{"source":"home_hero","section":"hero","variant":"duo"}',
+                "data-analytics-context":
+                  '{"source":"home_hero","section":"hero","variant":"duo"}',
               },
             }}
             gap="md"

--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -5,9 +5,14 @@ import type { ReactNode } from "react";
 import type { Metadata } from "next";
 import { Suspense } from "react";
 import { Button } from "@/components/ui/button";
-import { CALENDLY_URL } from "@/lib/config";
 import { Animate } from "@/components/ui/animate";
-import { Sheet, SheetContent, SheetTrigger, SheetTitle, SheetClose } from "@/components/ui/sheet";
+import {
+  Sheet,
+  SheetContent,
+  SheetTrigger,
+  SheetTitle,
+  SheetClose,
+} from "@/components/ui/sheet";
 import { Menu } from "lucide-react";
 import {
   NavigationMenu,
@@ -36,11 +41,11 @@ function buildNavigationItems() {
     label: "Case Studies",
     children: [
       { label: "All Case Studies", href: "/case-studies" },
-      ...caseStudies.map(study => ({
+      ...caseStudies.map((study) => ({
         label: study.company,
-        href: `/case-studies/${study.slug}`
-      }))
-    ]
+        href: `/case-studies/${study.slug}`,
+      })),
+    ],
   };
 
   return [
@@ -50,7 +55,7 @@ function buildNavigationItems() {
     { label: "About", href: "/about" },
     { label: "Blog", href: "/blog" },
     { label: "FAQ", href: "/faq" },
-    { label: "Book Demo", href: CALENDLY_URL, isButton: true },
+    { label: "Get Demo", href: "/get-demo", isButton: true },
   ] as (NavItem & { isButton?: boolean })[];
 }
 
@@ -61,8 +66,8 @@ const DesktopNavigation = () => {
   return (
     <NavigationMenu className="hidden md:block">
       <NavigationMenuList>
-        {navItems.map((item) => (
-          'children' in item ? (
+        {navItems.map((item) =>
+          "children" in item ? (
             <NavigationMenuItem key={item.label}>
               <NavigationMenuTrigger>{item.label}</NavigationMenuTrigger>
               <NavigationMenuContent>
@@ -87,12 +92,10 @@ const DesktopNavigation = () => {
                   asChild
                   size="sm"
                   data-analytics-id="nav_desktop_demo"
-                  data-analytics-name="Book Demo (Nav)"
+                  data-analytics-name="Get Demo (Nav)"
                   data-analytics-context='{"source":"nav_desktop","location":"header"}'
                 >
-                  <a href={item.href} target="_blank" rel="noopener noreferrer">
-                    {item.label}
-                  </a>
+                  <Link href={item.href}>{item.label}</Link>
                 </Button>
               ) : (
                 <NavigationMenuLink
@@ -103,8 +106,8 @@ const DesktopNavigation = () => {
                 </NavigationMenuLink>
               )}
             </NavigationMenuItem>
-          )
-        ))}
+          ),
+        )}
       </NavigationMenuList>
     </NavigationMenu>
   );
@@ -121,14 +124,19 @@ const MobileNavigation = () => {
           <span className="sr-only">Toggle mobile menu</span>
         </Button>
       </SheetTrigger>
-      <SheetContent side="right" className="w-[300px] sm:w-[400px] bg-transparent backdrop-blur-xl border-l border-border/50">
+      <SheetContent
+        side="right"
+        className="w-[300px] sm:w-[400px] bg-transparent backdrop-blur-xl border-l border-border/50"
+      >
         <SheetTitle className="sr-only">Navigation Menu</SheetTitle>
         <nav className="flex flex-col gap-4 mt-8 px-6">
           {navItems.map((item) => (
             <div key={item.label}>
-              {'children' in item ? (
+              {"children" in item ? (
                 <div className="space-y-2">
-                  <div className="font-medium text-foreground py-2">{item.label}</div>
+                  <div className="font-medium text-foreground py-2">
+                    {item.label}
+                  </div>
                   {item.children.map((child) => (
                     <SheetClose asChild key={child.label}>
                       <Link
@@ -146,12 +154,10 @@ const MobileNavigation = () => {
                     asChild
                     className="w-full"
                     data-analytics-id="nav_mobile_demo"
-                    data-analytics-name="Book Demo (Nav Mobile)"
+                    data-analytics-name="Get Demo (Nav Mobile)"
                     data-analytics-context='{"source":"nav_mobile","location":"sheet"}'
                   >
-                    <a href={item.href} target="_blank" rel="noopener noreferrer">
-                      {item.label}
-                    </a>
+                    <Link href={item.href}>{item.label}</Link>
                   </Button>
                 </SheetClose>
               ) : (
@@ -173,40 +179,50 @@ const MobileNavigation = () => {
 };
 
 export const metadata: Metadata = {
-  metadataBase: new URL(process.env.NEXT_PUBLIC_SITE_URL || 'https://www.subsights.com'),
+  metadataBase: new URL(
+    process.env.NEXT_PUBLIC_SITE_URL || "https://www.subsights.com",
+  ),
   title: {
-    template: '%s | Subsights AI',
-    default: 'Subsights AI - AI-Powered Website Conversion',
+    template: "%s | Subsights AI",
+    default: "Subsights AI - AI-Powered Website Conversion",
   },
-  description: 'Transform your website with AI-powered conversion tools. Increase leads, bookings, and revenue automatically.',
+  description:
+    "Transform your website with AI-powered conversion tools. Increase leads, bookings, and revenue automatically.",
   openGraph: {
-    type: 'website',
-    locale: 'en_US',
-    url: 'https://www.subsights.com',
-    siteName: 'Subsights AI',
+    type: "website",
+    locale: "en_US",
+    url: "https://www.subsights.com",
+    siteName: "Subsights AI",
     images: [
       {
-        url: '/images/logo/small-logo.svg',
+        url: "/images/logo/small-logo.svg",
         width: 1200,
         height: 630,
-        alt: 'Subsights AI Logo',
+        alt: "Subsights AI Logo",
       },
     ],
   },
   twitter: {
-    card: 'summary_large_image',
-    site: '@subsights',
-    images: ['/images/logo/small-logo.svg'],
+    card: "summary_large_image",
+    site: "@subsights",
+    images: ["/images/logo/small-logo.svg"],
   },
 };
 
 export default function SiteLayout({ children }: { children: ReactNode }) {
-
   return (
     <html lang="en" className="h-full">
       <head>
-        <link rel="icon" href="/images/logo/small-logo.svg" type="image/svg+xml" />
-        <link rel="shortcut icon" href="/images/logo/small-logo.svg" type="image/svg+xml" />
+        <link
+          rel="icon"
+          href="/images/logo/small-logo.svg"
+          type="image/svg+xml"
+        />
+        <link
+          rel="shortcut icon"
+          href="/images/logo/small-logo.svg"
+          type="image/svg+xml"
+        />
         <link rel="apple-touch-icon" href="/images/logo/small-logo.svg" />
         <ApolloTracker appId={process.env.NEXT_PUBLIC_APOLLO_APP_ID} />
         <script
@@ -218,7 +234,10 @@ export default function SiteLayout({ children }: { children: ReactNode }) {
       </head>
       <body className="bg-background text-foreground h-full">
         <AnalyticsProvider>
-          <div className="fixed inset-0 pointer-events-none" style={{ zIndex: -1 }}>
+          <div
+            className="fixed inset-0 pointer-events-none"
+            style={{ zIndex: -1 }}
+          >
             <div className="absolute left-[10%] top-[15%]">
               <FloatingOrb size="large" blur={40} opacity={0.4} speed={1} />
             </div>
@@ -226,14 +245,17 @@ export default function SiteLayout({ children }: { children: ReactNode }) {
               <FloatingOrb size="small" blur={40} opacity={0.4} speed={1.1} />
             </div>
             <div className="absolute left-[40%] top-[40%]">
-              <FloatingOrb size="medium" blur={40} opacity={0.40} speed={1.2} />
+              <FloatingOrb size="medium" blur={40} opacity={0.4} speed={1.2} />
             </div>
           </div>
 
           <header className="sticky top-0 z-50 border-b border-border/40  backdrop-blur-md shadow-sm transition-[background,backdrop-filter,box-shadow] duration-200 ease-out hover:backdrop-blur-xl hover:shadow-lg [animation:header-fade-in_linear_both] [animation-timeline:scroll(root)] [animation-range:0_100px] supports-[animation-timeline:scroll(root)]:animate-none">
             <Animate name="fadeIn" trigger="onLoad">
               <div className="mx-auto max-w-6xl px-6 py-4 flex items-center justify-between">
-                <Link href="/" className="flex items-center group rounded-lg transition-colors duration-150 ease-out hover:bg-white/10">
+                <Link
+                  href="/"
+                  className="flex items-center group rounded-lg transition-colors duration-150 ease-out hover:bg-white/10"
+                >
                   <Image
                     src="/images/logo/full-logo.svg"
                     alt="Subsights AI"
@@ -253,7 +275,10 @@ export default function SiteLayout({ children }: { children: ReactNode }) {
           <footer className="mx-auto max-w-6xl px-6 py-12">
             <div className="flex flex-col items-center space-y-6 text-center">
               {/* Logo */}
-              <Link href="/" className="flex items-center group rounded-lg transition-colors duration-150 ease-out hover:bg-white/10">
+              <Link
+                href="/"
+                className="flex items-center group rounded-lg transition-colors duration-150 ease-out hover:bg-white/10"
+              >
                 <Image
                   src="/images/logo/full-logo.svg"
                   alt="Subsights AI"
@@ -265,13 +290,22 @@ export default function SiteLayout({ children }: { children: ReactNode }) {
 
               {/* Legal Links */}
               <div className="flex flex-wrap justify-center gap-6 text-sm text-muted-foreground">
-                <Link href="/legal/terms" className="hover:text-foreground transition-colors">
+                <Link
+                  href="/legal/terms"
+                  className="hover:text-foreground transition-colors"
+                >
                   Terms of Service
                 </Link>
-                <Link href="/legal/privacy" className="hover:text-foreground transition-colors">
+                <Link
+                  href="/legal/privacy"
+                  className="hover:text-foreground transition-colors"
+                >
                   Privacy Policy
                 </Link>
-                <Link href="/legal/data-processing" className="hover:text-foreground transition-colors">
+                <Link
+                  href="/legal/data-processing"
+                  className="hover:text-foreground transition-colors"
+                >
                   Data Processing
                 </Link>
               </div>


### PR DESCRIPTION
## Summary
- replace Book Demo links with internal Get Demo route and updated analytics
- add new /get-demo page with booking option and demo request form

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b1db8090908327b78e3ed610af4369